### PR TITLE
Add an older ID of XArcade device

### DIFF
--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -81,6 +81,7 @@ int findXarcadeDevice(void) {
 
 		ioctl(fevdev, EVIOCGNAME(sizeof(name)), name);
 		if ((strcmp(name, "XGaming X-Arcade") == 0)
+                    || (strcmp(name, "Xgaming  X-Arcade") == 0)
 		    || (strcmp(name, "Ultimarc") == 0) 
 		    || (strcmp(name, "XGaming USBAdapter") == 0)) {
 			printf("Found %s (%s)\n", filename, name);


### PR DESCRIPTION
I had to make this update to make it run on my own XArcade (older PS2 model with USB adapters)